### PR TITLE
fix(orderedmap): fix set bug

### DIFF
--- a/maputil/orderedmap.go
+++ b/maputil/orderedmap.go
@@ -35,7 +35,7 @@ func (om *OrderedMap[K, V]) Set(key K, value V) {
 	defer om.mu.Unlock()
 
 	if elem, ok := om.index[key]; ok {
-		elem.Value = value
+		om.data[key] = value
 		om.order.MoveToBack(elem)
 
 		return

--- a/maputil/orderedmap_test.go
+++ b/maputil/orderedmap_test.go
@@ -19,6 +19,10 @@ func TestOrderedMap_Set_Get(t *testing.T) {
 	assert.Equal(1, val)
 	assert.Equal(true, ok)
 
+	om.Set("a", 2)
+	val, _ = om.Get("a")
+	assert.Equal(2, val)
+
 	val, ok = om.Get("d")
 	assert.Equal(false, ok)
 	assert.Equal(0, val)


### PR DESCRIPTION
set : when the key is present, the value of the data map should be set, not the value of the list

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Fix a bug in the `OrderedMap` by updating the `Set` method to properly assign new values to the map, and add corresponding unit tests to validate this fix.

### Why are these changes being made?

The previous implementation of the `Set` method incorrectly assigned values only to the map element's list, rather than the underlying data map, which caused inconsistencies. The added test verifies that `Set` updates the value as expected, specifically addressing the bug where updating an existing key did not persist the change correctly.

> Is this description stale? Ask me to generate a new description by commenting `/korbit-generate-pr-description`
<!-- Korbit AI PR Description End -->
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes bug in `OrderedMap`'s `Set` method to correctly update value in data map, with test added to verify fix.
> 
>   - **Bug Fix**:
>     - Fixes bug in `Set` method of `OrderedMap` in `orderedmap.go` where value was incorrectly set in list element instead of data map.
>   - **Testing**:
>     - Adds test in `orderedmap_test.go` to verify correct value update when setting an existing key.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=congziqi77%2Flancet&utm_source=github&utm_medium=referral)<sup> for 2ae9d0a246ee9a9b5601309fb3e064970cd23aea. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Enhanced the update mechanism for the ordered map to ensure key value modifications are applied more consistently.
  
- **Tests**
  - Expanded test coverage to confirm that updating an existing key now reflects the correct new value.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->